### PR TITLE
Modifying Readme instruction to have the same variables for Genfit and Pathfinder

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,10 +178,10 @@ make
 To compile with Genie and GenFit support, do
 ```
 export GENIE=$INSTALL_PATH/GENIE
-export GENFIT_INCLUDE=/** PATH TO Downloaded GenFit directory **/
-export GENFIT_LIBRARY=/** PATH TO the bin directory in the used build folder**/
-export PATHFINDER_INC=/** PATHFINDER_SOURCES **/include
-export PATHFINDER_LIB=/** PATHFINDER_BUILD_DIR **/lib
+export GENFIT_HOME=/** PATH TO Downloaded GenFit directory **/
+export GENFIT_BUILD=/** PATH TO the build directory in the used build folder**/
+export PATHFINDER_HOME=/** PATHFINDER extracted directory containing the sources **/
+export PATHFINDER_BUILD=/** PATHFINDER build directory **/
 cmake -DWITH_GENIE=ON -DWITH_GENFIT=ON ..
 make
 ```


### PR DESCRIPTION
Variables should be the same in point 5 as in point 4 - home and build directories for GenFit and Pathfinder are required.